### PR TITLE
Bugfix/objects 992 no response for existing thing

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -9,6 +9,7 @@ No new features are added in this release.
 === Bugfixes & Improvements
 
 * OBJECTS-985 Things Edge GET endpoints ignore Paging
+* OBJECTS-992 Thing creation doesn't return a response in case of conflict
 
 == Release 3.0.0 (August 12, 2016)
 

--- a/src/main/java/net/smartcosmos/edge/things/rest/ConflictOauth2ErrorHandler.java
+++ b/src/main/java/net/smartcosmos/edge/things/rest/ConflictOauth2ErrorHandler.java
@@ -1,0 +1,30 @@
+package net.smartcosmos.edge.things.rest;
+
+import java.io.IOException;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.security.oauth2.client.http.OAuth2ErrorHandler;
+import org.springframework.security.oauth2.client.resource.OAuth2ProtectedResourceDetails;
+import org.springframework.stereotype.Component;
+
+/**
+ * Error handler component that, in addition to the typical "No Error" HTTP response status codes, also accepts 409 Conflict as no error.
+ */
+@Component
+public class ConflictOauth2ErrorHandler extends OAuth2ErrorHandler {
+
+    @Autowired
+    public ConflictOauth2ErrorHandler(OAuth2ProtectedResourceDetails resource) {
+
+        super(resource);
+    }
+
+    @Override
+    public boolean hasError(ClientHttpResponse response) throws IOException {
+
+        HttpStatus status = response.getStatusCode();
+        return !(status.is2xxSuccessful() || status.is3xxRedirection() || status.is1xxInformational() || HttpStatus.CONFLICT.equals(status));
+    }
+}

--- a/src/main/java/net/smartcosmos/edge/things/rest/RestTemplateFactory.java
+++ b/src/main/java/net/smartcosmos/edge/things/rest/RestTemplateFactory.java
@@ -22,14 +22,20 @@ public class RestTemplateFactory {
     private final RibbonClientHttpRequestFactory ribbonClientHttpRequestFactory;
 
     private final OAuth2TokenProvider tokenProvider;
+    private final ConflictOauth2ErrorHandler errorHandler;
 
     @Autowired
-    public RestTemplateFactory(SpringClientFactory clientFactory, OAuth2ProtectedResourceDetails resourceDetails, OAuth2TokenProvider tokenProvider) {
+    public RestTemplateFactory(
+        SpringClientFactory clientFactory,
+        OAuth2ProtectedResourceDetails resourceDetails,
+        OAuth2TokenProvider tokenProvider,
+        ConflictOauth2ErrorHandler errorHandler) {
 
         this.ribbonClientHttpRequestFactory = new RibbonClientHttpRequestFactory(clientFactory);
 
         this.resourceDetails = resourceDetails;
         this.tokenProvider = tokenProvider;
+        this.errorHandler = errorHandler;
     }
 
     /**
@@ -47,6 +53,7 @@ public class RestTemplateFactory {
 
         OAuth2RestTemplate restTemplate = new OAuth2RestTemplate(resourceDetails, context);
         restTemplate.setRequestFactory(ribbonClientHttpRequestFactory);
+        restTemplate.setErrorHandler(errorHandler);
 
         return restTemplate;
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

If the Things Local service returned a *409 Conflict* response, a `HttpClientErrorException` was thrown, which actually should result in a corresponding response. However, although a response was set (and unit tests passed), the actual test in Postman couldn't get any response.

To (hopefully) avoid this, the method setting the result for `DeferredResult` has now a `catch` block for any exceptions, so that an error result will be set.

In addition, a custom OAuth2 error handler is added, which doesn't consider *409 Conflict* as an error and therefore won't throw an exception.

Moreover, `CreateThingEdgeServiceDefault` is changed, so that the `force` flag is taken into account in case of conflicts. Previously, the request processing was aborted, regardless of the flag's value. Now, metadata is updated if the Thing already existed, too.

### How is this patch documented?

Code.

### How was this patch tested?

- Unit tests
- Postman

#### Depends On

Nothing.