### PR TITLE
Build new responses instead of forwarding the received

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -10,6 +10,7 @@ No new features are added in this release.
 
 * OBJECTS-985 Things Edge GET endpoints ignore Paging
 * OBJECTS-992 Thing creation doesn't return a response in case of conflict
+* OBJECTS-996 Response Forwarding in intermediate services may have unwanted side effects
 
 == Release 3.0.0 (August 12, 2016)
 

--- a/src/main/java/net/smartcosmos/edge/things/service/CreateThingEdgeServiceDefault.java
+++ b/src/main/java/net/smartcosmos/edge/things/service/CreateThingEdgeServiceDefault.java
@@ -18,6 +18,8 @@ import net.smartcosmos.edge.things.service.local.metadata.CreateMetadataRestServ
 import net.smartcosmos.edge.things.service.local.things.CreateThingRestService;
 import net.smartcosmos.security.user.SmartCosmosUser;
 
+import static net.smartcosmos.edge.things.utility.ResponseBuilderUtility.buildForwardingResponse;
+
 /**
  * Default implementation for {@link net.smartcosmos.edge.things.service.CreateThingEdgeService}
  */
@@ -73,11 +75,11 @@ public class CreateThingEdgeServiceDefault implements CreateThingEdgeService {
             if (!metadataResponse.getStatusCode()
                 .is2xxSuccessful()) {
                 // if there was a problem with the metadata creation, we return that
-                return metadataResponse;
+                return buildForwardingResponse(metadataResponse);
             }
         }
 
         // usually we just return the Thing creation response
-        return thingResponse;
+        return buildForwardingResponse(thingResponse);
     }
 }

--- a/src/main/java/net/smartcosmos/edge/things/service/DeleteThingEdgeServiceDefault.java
+++ b/src/main/java/net/smartcosmos/edge/things/service/DeleteThingEdgeServiceDefault.java
@@ -1,5 +1,7 @@
 package net.smartcosmos.edge.things.service;
 
+import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.http.HttpStatus;
@@ -12,10 +14,13 @@ import net.smartcosmos.edge.things.service.local.metadata.DeleteMetadataRestServ
 import net.smartcosmos.edge.things.service.local.things.DeleteThingRestService;
 import net.smartcosmos.security.user.SmartCosmosUser;
 
+import static net.smartcosmos.edge.things.utility.ResponseBuilderUtility.buildForwardingResponse;
+
 /**
  * Default implementation for {@link net.smartcosmos.edge.things.service.DeleteThingEdgeService}
  */
 @Service
+@Slf4j
 public class DeleteThingEdgeServiceDefault implements DeleteThingEdgeService {
 
     private final EventSendingService eventSendingService;
@@ -24,8 +29,10 @@ public class DeleteThingEdgeServiceDefault implements DeleteThingEdgeService {
     private final DeleteThingRestService deleteThingService;
 
     @Autowired
-    public DeleteThingEdgeServiceDefault(EventSendingService eventSendingService, ConversionService conversionService,
-            DeleteMetadataRestService deleteMetadataService, DeleteThingRestService deleteThingService) {
+    public DeleteThingEdgeServiceDefault(
+        EventSendingService eventSendingService, ConversionService conversionService,
+        DeleteMetadataRestService deleteMetadataService, DeleteThingRestService deleteThingService) {
+
         this.eventSendingService = eventSendingService;
         this.conversionService = conversionService;
         this.deleteMetadataService = deleteMetadataService;
@@ -37,18 +44,29 @@ public class DeleteThingEdgeServiceDefault implements DeleteThingEdgeService {
     @Override
     public void delete(DeferredResult<ResponseEntity> response, String type, String urn, SmartCosmosUser user) {
 
+        try {
+            response.setResult(deleteWorker(type, urn, user));
+        } catch (Exception e) {
+            log.debug(e.getMessage(), e);
+            response.setErrorResult(e);
+        }
+    }
+
+    protected ResponseEntity<?> deleteWorker(String type, String urn, SmartCosmosUser user) {
+
         ResponseEntity thingResponse = deleteThingService.delete(type, urn, user);
 
-        if (thingResponse.getStatusCode().is2xxSuccessful()) {
+        if (thingResponse.getStatusCode()
+            .is2xxSuccessful()) {
             ResponseEntity metadataResponse = deleteMetadataService.delete(type, urn, user);
 
-            if (!metadataResponse.getStatusCode().is2xxSuccessful() && HttpStatus.NOT_FOUND != metadataResponse.getStatusCode()) {
+            if (!metadataResponse.getStatusCode()
+                .is2xxSuccessful() && HttpStatus.NOT_FOUND != metadataResponse.getStatusCode()) {
                 // if there was a problem with the metadata deletion, we return that (but 404 Not Found is okay)
-                response.setResult(metadataResponse);
-                return;
+                return buildForwardingResponse(metadataResponse);
             }
         }
 
-        response.setResult(thingResponse);
+        return buildForwardingResponse(thingResponse);
     }
 }

--- a/src/main/java/net/smartcosmos/edge/things/service/GetThingEdgeServiceDefault.java
+++ b/src/main/java/net/smartcosmos/edge/things/service/GetThingEdgeServiceDefault.java
@@ -25,6 +25,8 @@ import net.smartcosmos.edge.things.service.local.metadata.GetMetadataRestService
 import net.smartcosmos.edge.things.service.local.things.GetThingRestService;
 import net.smartcosmos.security.user.SmartCosmosUser;
 
+import static net.smartcosmos.edge.things.utility.ResponseBuilderUtility.buildForwardingResponse;
+
 @Service
 public class GetThingEdgeServiceDefault implements GetThingEdgeService {
 
@@ -54,7 +56,7 @@ public class GetThingEdgeServiceDefault implements GetThingEdgeService {
 
         ResponseEntity thingResponse = getThingService.findByTypeAndUrn(type, urn, user);
         if (!thingResponse.getStatusCode().is2xxSuccessful()) {
-            return thingResponse;
+            return buildForwardingResponse(thingResponse);
         }
 
         Map<String, Object> resultMap = new LinkedHashMap<>();
@@ -93,7 +95,7 @@ public class GetThingEdgeServiceDefault implements GetThingEdgeService {
 
         ResponseEntity thingResponse = getThingService.findByType(type, page, size, sortOrder, sortBy, user);
         if (!thingResponse.getStatusCode().is2xxSuccessful()) {
-            return thingResponse;
+            return buildForwardingResponse(thingResponse);
         }
 
         if (thingResponse.hasBody() && thingResponse.getBody() instanceof RestPagedThingResponse) {
@@ -115,7 +117,7 @@ public class GetThingEdgeServiceDefault implements GetThingEdgeService {
             }
         }
 
-        return thingResponse;
+        return buildForwardingResponse(thingResponse);
     }
 
     private ResponseEntity<?> getMetadataOwnerMergeThings(String type, Set<String> metadataKeys, Integer page, Integer size, String sortOrder, String sortBy, SmartCosmosUser user) {

--- a/src/main/java/net/smartcosmos/edge/things/service/UpdateThingEdgeServiceDefault.java
+++ b/src/main/java/net/smartcosmos/edge/things/service/UpdateThingEdgeServiceDefault.java
@@ -2,6 +2,8 @@ package net.smartcosmos.edge.things.service;
 
 import java.util.Map;
 
+import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.http.ResponseEntity;
@@ -13,13 +15,16 @@ import net.smartcosmos.edge.things.domain.RestThingMetadataUpdateContainer;
 import net.smartcosmos.edge.things.domain.local.things.RestThingUpdate;
 import net.smartcosmos.edge.things.service.local.metadata.UpsertMetadataRestService;
 import net.smartcosmos.edge.things.service.local.things.UpdateThingRestService;
-import net.smartcosmos.edge.things.utility.ResponseBuilderUtility;
 import net.smartcosmos.security.user.SmartCosmosUser;
+
+import static net.smartcosmos.edge.things.utility.ResponseBuilderUtility.buildBadRequestResponse;
+import static net.smartcosmos.edge.things.utility.ResponseBuilderUtility.buildForwardingResponse;
 
 /**
  * Default implementation for {@link net.smartcosmos.edge.things.service.UpdateThingEdgeService}
  */
 @Service
+@Slf4j
 public class UpdateThingEdgeServiceDefault implements UpdateThingEdgeService {
 
     private final EventSendingService eventSendingService;
@@ -28,8 +33,10 @@ public class UpdateThingEdgeServiceDefault implements UpdateThingEdgeService {
     private final UpdateThingRestService updateThingService;
 
     @Autowired
-    public UpdateThingEdgeServiceDefault(EventSendingService eventSendingService, ConversionService conversionService,
-            UpsertMetadataRestService upsertMetadataService, UpdateThingRestService updateThingService) {
+    public UpdateThingEdgeServiceDefault(
+        EventSendingService eventSendingService, ConversionService conversionService,
+        UpsertMetadataRestService upsertMetadataService, UpdateThingRestService updateThingService) {
+
         this.eventSendingService = eventSendingService;
         this.conversionService = conversionService;
         this.upsertMetadataService = upsertMetadataService;
@@ -41,6 +48,16 @@ public class UpdateThingEdgeServiceDefault implements UpdateThingEdgeService {
     @Override
     public void update(DeferredResult<ResponseEntity> response, String type, String urn, Map<String, Object> requestBody, SmartCosmosUser user) {
 
+        try {
+            response.setResult(updateWorker(type, urn, requestBody, user));
+        } catch (Exception e) {
+            log.debug(e.getMessage(), e);
+            response.setErrorResult(e);
+        }
+    }
+
+    protected ResponseEntity<?> updateWorker(String type, String urn, Map<String, Object> requestBody, SmartCosmosUser user) {
+
         RestThingMetadataUpdateContainer container = conversionService.convert(requestBody, RestThingMetadataUpdateContainer.class);
 
         Map<String, Object> reducedMetadataMap = container.getMetadataRequestBody();
@@ -48,30 +65,29 @@ public class UpdateThingEdgeServiceDefault implements UpdateThingEdgeService {
 
         if (thingUpdate == null && reducedMetadataMap.isEmpty()) {
             // if there is nothing to update, we return 400 Bad Request
-            ResponseEntity nothingToUpdate = ResponseBuilderUtility.buildBadRequestResponse(1, "Nothing to update");
-            response.setResult(nothingToUpdate);
-            return;
+            return buildBadRequestResponse(1, "Nothing to update");
         }
 
         if (thingUpdate != null) {
             ResponseEntity thingResponse = updateThingService.update(type, urn, thingUpdate, user);
-            if (!thingResponse.getStatusCode().is2xxSuccessful()) {
+            if (!thingResponse.getStatusCode()
+                .is2xxSuccessful()) {
                 // if there was a problem with the thing update, we return that
-                response.setResult(thingResponse);
-                return;
+                return buildForwardingResponse(thingResponse);
             }
         }
 
         if (!reducedMetadataMap.isEmpty()) {
             ResponseEntity metadataResponse = upsertMetadataService.upsert(type, urn, reducedMetadataMap, user);
-            if (!metadataResponse.getStatusCode().is2xxSuccessful()) {
+            if (!metadataResponse.getStatusCode()
+                .is2xxSuccessful()) {
                 // if there was a problem with the metadata update, we return that
-                response.setResult(metadataResponse);
-                return;
+                return buildForwardingResponse(metadataResponse);
             }
         }
 
         // usually we just return 204 No Content
-        response.setResult(ResponseEntity.noContent().build());
+        return ResponseEntity.noContent()
+            .build();
     }
 }

--- a/src/main/java/net/smartcosmos/edge/things/utility/ResponseBuilderUtility.java
+++ b/src/main/java/net/smartcosmos/edge/things/utility/ResponseBuilderUtility.java
@@ -23,4 +23,16 @@ public class ResponseBuilderUtility {
                       .build());
     }
 
+    /**
+     * Builds a {@link ResponseEntity} based on the HTTP status code and body of another response.
+     *
+     * @param response the existing response
+     * @return a new response with the same HTTP status code and body
+     */
+    public static ResponseEntity<?> buildForwardingResponse(ResponseEntity<?> response) {
+
+        return ResponseEntity.status(response.getStatusCode())
+            .body(response.getBody());
+    }
+
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
- adds a `ResponseBuilderUtility` method to build new responses from received responses
- replaces simply forwarded responses by new ones created with the utility method
### How is this patch documented?
- Code
- Javadoc

Also see this Slack message: https://smartrac.slack.com/archives/platform/p1471872371000005
### How was this patch tested?

Existing unit tests
#### Depends On

Nothing.
