### PR TITLE
Add @EnableSmartCosmosMonitoring

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -4,7 +4,7 @@
 
 === New Features
 
-No new features are added in this release.
+* OBJECTS-980 Add Prometheus-compatible `/metrics` endpoint
 
 === Bugfixes & Improvements
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>net.smartcosmos</groupId>
         <artifactId>smartcosmos-framework-parent</artifactId>
-        <version>3.0.0</version>
+        <version>3.0.1-SNAPSHOT</version>
         <relativePath></relativePath>
     </parent>
 
@@ -45,6 +45,10 @@
         <dependency>
             <groupId>net.smartcosmos</groupId>
             <artifactId>smartcosmos-framework</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.smartcosmos</groupId>
+            <artifactId>smartcosmos-framework-monitoring</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.cloud</groupId>

--- a/src/main/java/net/smartcosmos/edge/things/ThingEdgeService.java
+++ b/src/main/java/net/smartcosmos/edge/things/ThingEdgeService.java
@@ -7,11 +7,13 @@ import org.springframework.context.annotation.Import;
 
 import net.smartcosmos.annotation.EnableSmartCosmosEvents;
 import net.smartcosmos.annotation.EnableSmartCosmosExtension;
+import net.smartcosmos.annotation.EnableSmartCosmosMonitoring;
 import net.smartcosmos.annotation.EnableSmartCosmosSecurity;
 import net.smartcosmos.edge.things.config.ThingsEdgeConfiguration;
 
 @EnableSmartCosmosExtension
 @EnableSmartCosmosEvents
+@EnableSmartCosmosMonitoring
 @EnableSmartCosmosSecurity
 @EnableSwagger2
 @Import(ThingsEdgeConfiguration.class)


### PR DESCRIPTION
### What changes were proposed in this pull request?

adds the `@EnableSmartCosmosMonitoring` annotation which adds a new `/metrics` endpoint for Prometheus 

### How is this patch documented?

- Code
- Javadoc in Framework

### How was this patch tested?

manually

#### Depends On

https://github.com/SMARTRACTECHNOLOGY/smartcosmos-framework/pull/196