### PR TITLE
Feature/objects 1035

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -13,6 +13,7 @@
 * OBJECTS-996 Response Forwarding in intermediate services may have unwanted side effects
 * OBJECTS-997 URL parameter aren't encoded
 * OBJECTS-1006 Refactor inter-service calls and remove RestConnector classes
+* OBJECTS-1035 Improve logging for smartcosmos-edge-things
 * PROFILES-667: add zipkin starter for distributed tracing
 
 == Release 3.0.0 (August 12, 2016)

--- a/src/main/java/net/smartcosmos/edge/things/service/CreateThingEdgeServiceDefault.java
+++ b/src/main/java/net/smartcosmos/edge/things/service/CreateThingEdgeServiceDefault.java
@@ -45,8 +45,9 @@ public class CreateThingEdgeServiceDefault implements CreateThingEdgeService {
         try {
             response.setResult(createWorker(type, metadataMap, force, user));
         } catch (Exception e) {
-            log.error(createByTypeLogMessage(type, user, e.toString(), force, metadataMap.toString()));
-            log.debug(createByTypeLogMessage(type, user, e.toString(), force, metadataMap.toString()), e);
+            String msg = createByTypeLogMessage(type, user, e.toString(), force, metadataMap.toString());
+            log.error(msg);
+            log.debug(msg, e);
             response.setErrorResult(e);
         }
     }

--- a/src/main/java/net/smartcosmos/edge/things/service/DeleteThingEdgeServiceDefault.java
+++ b/src/main/java/net/smartcosmos/edge/things/service/DeleteThingEdgeServiceDefault.java
@@ -38,8 +38,9 @@ public class DeleteThingEdgeServiceDefault implements DeleteThingEdgeService {
         try {
             response.setResult(deleteWorker(type, urn, user));
         } catch (Exception e) {
-            log.error(deleteByTypeAndUrnLogMessage(type, urn, user, e.toString()));
-            log.debug(deleteByTypeAndUrnLogMessage(type, urn, user, e.toString()), e);
+            String msg = deleteByTypeAndUrnLogMessage(type, urn, user, e.toString());
+            log.error(msg);
+            log.debug(msg, e);
             response.setErrorResult(e);
         }
     }

--- a/src/main/java/net/smartcosmos/edge/things/service/DeleteThingEdgeServiceDefault.java
+++ b/src/main/java/net/smartcosmos/edge/things/service/DeleteThingEdgeServiceDefault.java
@@ -3,13 +3,11 @@ package net.smartcosmos.edge.things.service;
 import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.convert.ConversionService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.context.request.async.DeferredResult;
 
-import net.smartcosmos.edge.things.service.event.EventSendingService;
 import net.smartcosmos.edge.things.service.metadata.DeleteMetadataRestService;
 import net.smartcosmos.edge.things.service.things.DeleteThingRestService;
 import net.smartcosmos.security.user.SmartCosmosUser;
@@ -23,18 +21,13 @@ import static net.smartcosmos.edge.things.util.ResponseBuilderUtility.buildForwa
 @Slf4j
 public class DeleteThingEdgeServiceDefault implements DeleteThingEdgeService {
 
-    private final EventSendingService eventSendingService;
-    private final ConversionService conversionService;
     private final DeleteMetadataRestService deleteMetadataService;
     private final DeleteThingRestService deleteThingService;
 
     @Autowired
     public DeleteThingEdgeServiceDefault(
-        EventSendingService eventSendingService, ConversionService conversionService,
         DeleteMetadataRestService deleteMetadataService, DeleteThingRestService deleteThingService) {
 
-        this.eventSendingService = eventSendingService;
-        this.conversionService = conversionService;
         this.deleteMetadataService = deleteMetadataService;
         this.deleteThingService = deleteThingService;
     }
@@ -45,12 +38,8 @@ public class DeleteThingEdgeServiceDefault implements DeleteThingEdgeService {
         try {
             response.setResult(deleteWorker(type, urn, user));
         } catch (Exception e) {
-            log.warn("Delete request for Thing with type '{}' and URN '{}' by user {} failed: {}",
-                     type,
-                     urn,
-                     user,
-                     e.toString());
-            log.debug(e.toString(), e);
+            log.error(deleteByTypeAndUrnLogMessage(type, urn, user, e.toString()));
+            log.debug(deleteByTypeAndUrnLogMessage(type, urn, user, e.toString()), e);
             response.setErrorResult(e);
         }
     }
@@ -68,8 +57,18 @@ public class DeleteThingEdgeServiceDefault implements DeleteThingEdgeService {
                 // if there was a problem with the metadata deletion, we return that (but 404 Not Found is okay)
                 return buildForwardingResponse(metadataResponse);
             }
+        } else {
+            log.warn(deleteByTypeAndUrnLogMessage(type, urn, user, thingResponse.toString()));
         }
 
         return buildForwardingResponse(thingResponse);
+    }
+
+    private String deleteByTypeAndUrnLogMessage(String type, String urn, SmartCosmosUser user, String message) {
+        return String.format("Delete request for Thing with type '%s' and urn '%s' by user '%s' failed: %s",
+                             type,
+                             urn,
+                             user,
+                             message);
     }
 }

--- a/src/main/java/net/smartcosmos/edge/things/service/GetThingEdgeServiceDefault.java
+++ b/src/main/java/net/smartcosmos/edge/things/service/GetThingEdgeServiceDefault.java
@@ -74,8 +74,9 @@ public class GetThingEdgeServiceDefault implements GetThingEdgeService {
             Map<String, Object> metadaResponseMap = getMetadataForThing(type, urn, metadataKeys, user);
             resultMap.putAll(metadaResponseMap);
         } catch (RestException e) {
-            log.error(getByTypeAndUrnLogMessage(type, urn, user, e.toString()));
-            log.debug(getByTypeAndUrnLogMessage(type, urn, user, e.toString()), e);
+            String msg = getByTypeAndUrnLogMessage(type, urn, user, e.toString());
+            log.error(msg);
+            log.debug(msg, e);
             return e.getResponseEntity();
         }
 
@@ -128,8 +129,9 @@ public class GetThingEdgeServiceDefault implements GetThingEdgeService {
                     .contentType(MediaType.APPLICATION_JSON_UTF8)
                     .body(responsePage);
             } catch (RestException e) {
-                log.error(getByTypeLogMessage(type, user, e.toString()));
-                log.debug(getByTypeLogMessage(type, user, e.toString()), e);
+                String msg = getByTypeLogMessage(type, user, e.toString());
+                log.error(msg);
+                log.debug(msg, e);
                 return e.getResponseEntity();
             }
         }

--- a/src/main/java/net/smartcosmos/edge/things/service/GetThingEdgeServiceDefault.java
+++ b/src/main/java/net/smartcosmos/edge/things/service/GetThingEdgeServiceDefault.java
@@ -192,14 +192,14 @@ public class GetThingEdgeServiceDefault implements GetThingEdgeService {
     }
 
     private String getByTypeLogMessage(String type, SmartCosmosUser user, String message) {
-        return String.format("Read request for Thing with type '%s' by user '%S' failed: %s",
+        return String.format("Read request for Thing with type '%s' by user '%s' failed: %s",
                              type,
                              user,
                              message);
     }
 
     private String getByTypeAndUrnLogMessage(String type, String urn, SmartCosmosUser user, String message) {
-        return String.format("Read request for Thing with type '%s' and urn '%s' by user '%S' failed: %s",
+        return String.format("Read request for Thing with type '%s' and urn '%s' by user '%s' failed: %s",
                              type,
                              urn,
                              user,

--- a/src/main/java/net/smartcosmos/edge/things/service/UpdateThingEdgeServiceDefault.java
+++ b/src/main/java/net/smartcosmos/edge/things/service/UpdateThingEdgeServiceDefault.java
@@ -12,7 +12,6 @@ import org.springframework.web.context.request.async.DeferredResult;
 
 import net.smartcosmos.edge.things.domain.RestThingMetadataUpdateContainer;
 import net.smartcosmos.edge.things.domain.things.RestThingUpdate;
-import net.smartcosmos.edge.things.service.event.EventSendingService;
 import net.smartcosmos.edge.things.service.metadata.UpsertMetadataRestService;
 import net.smartcosmos.edge.things.service.things.UpdateThingRestService;
 import net.smartcosmos.security.user.SmartCosmosUser;
@@ -27,17 +26,14 @@ import static net.smartcosmos.edge.things.util.ResponseBuilderUtility.buildForwa
 @Slf4j
 public class UpdateThingEdgeServiceDefault implements UpdateThingEdgeService {
 
-    private final EventSendingService eventSendingService;
     private final ConversionService conversionService;
     private final UpsertMetadataRestService upsertMetadataService;
     private final UpdateThingRestService updateThingService;
 
     @Autowired
     public UpdateThingEdgeServiceDefault(
-        EventSendingService eventSendingService, ConversionService conversionService,
-        UpsertMetadataRestService upsertMetadataService, UpdateThingRestService updateThingService) {
+        ConversionService conversionService, UpsertMetadataRestService upsertMetadataService, UpdateThingRestService updateThingService) {
 
-        this.eventSendingService = eventSendingService;
         this.conversionService = conversionService;
         this.upsertMetadataService = upsertMetadataService;
         this.updateThingService = updateThingService;
@@ -49,7 +45,7 @@ public class UpdateThingEdgeServiceDefault implements UpdateThingEdgeService {
         try {
             response.setResult(updateWorker(type, urn, requestBody, user));
         } catch (Exception e) {
-            log.warn(updateByTypeAndUrnLogMessage(type, urn, user, e.toString(), requestBody.toString()));
+            log.error(updateByTypeAndUrnLogMessage(type, urn, user, e.toString(), requestBody.toString()));
             log.debug(updateByTypeAndUrnLogMessage(type, urn, user, e.toString(), requestBody.toString()), e);
             response.setErrorResult(e);
         }

--- a/src/main/java/net/smartcosmos/edge/things/service/UpdateThingEdgeServiceDefault.java
+++ b/src/main/java/net/smartcosmos/edge/things/service/UpdateThingEdgeServiceDefault.java
@@ -45,8 +45,9 @@ public class UpdateThingEdgeServiceDefault implements UpdateThingEdgeService {
         try {
             response.setResult(updateWorker(type, urn, requestBody, user));
         } catch (Exception e) {
-            log.error(updateByTypeAndUrnLogMessage(type, urn, user, e.toString(), requestBody.toString()));
-            log.debug(updateByTypeAndUrnLogMessage(type, urn, user, e.toString(), requestBody.toString()), e);
+            String msg = updateByTypeAndUrnLogMessage(type, urn, user, e.toString(), requestBody.toString());
+            log.error(msg);
+            log.debug(msg, e);
             response.setErrorResult(e);
         }
     }

--- a/src/main/java/net/smartcosmos/edge/things/service/UpdateThingEdgeServiceDefault.java
+++ b/src/main/java/net/smartcosmos/edge/things/service/UpdateThingEdgeServiceDefault.java
@@ -49,13 +49,8 @@ public class UpdateThingEdgeServiceDefault implements UpdateThingEdgeService {
         try {
             response.setResult(updateWorker(type, urn, requestBody, user));
         } catch (Exception e) {
-            log.warn("Update request for Thing with type '{}' and URN '{}' by user {} failed: {}\nRequest: {}",
-                     type,
-                     urn,
-                     user,
-                     e.toString(),
-                     requestBody);
-            log.debug(e.toString(), e);
+            log.warn(updateByTypeAndUrnLogMessage(type, urn, user, e.toString(), requestBody.toString()));
+            log.debug(updateByTypeAndUrnLogMessage(type, urn, user, e.toString(), requestBody.toString()), e);
             response.setErrorResult(e);
         }
     }
@@ -69,6 +64,7 @@ public class UpdateThingEdgeServiceDefault implements UpdateThingEdgeService {
 
         if (thingUpdate == null && reducedMetadataMap.isEmpty()) {
             // if there is nothing to update, we return 400 Bad Request
+            log.warn(updateByTypeAndUrnLogMessage(type, urn, user, "Nothing to update", requestBody.toString()));
             return buildBadRequestResponse(1, "Nothing to update");
         }
 
@@ -77,6 +73,7 @@ public class UpdateThingEdgeServiceDefault implements UpdateThingEdgeService {
             if (!thingResponse.getStatusCode()
                 .is2xxSuccessful()) {
                 // if there was a problem with the thing update, we return that
+                log.warn(updateByTypeAndUrnLogMessage(type, urn, user, "update core thing = " + thingResponse.toString(), requestBody.toString()));
                 return buildForwardingResponse(thingResponse);
             }
         }
@@ -86,6 +83,7 @@ public class UpdateThingEdgeServiceDefault implements UpdateThingEdgeService {
             if (!metadataResponse.getStatusCode()
                 .is2xxSuccessful()) {
                 // if there was a problem with the metadata update, we return that
+                log.warn(updateByTypeAndUrnLogMessage(type, urn, user, "update core metadata = " + metadataResponse.toString(), requestBody.toString()));
                 return buildForwardingResponse(metadataResponse);
             }
         }
@@ -93,5 +91,14 @@ public class UpdateThingEdgeServiceDefault implements UpdateThingEdgeService {
         // usually we just return 204 No Content
         return ResponseEntity.noContent()
             .build();
+    }
+
+    private String updateByTypeAndUrnLogMessage(String type, String urn, SmartCosmosUser user, String message, String requestBody) {
+        return String.format("Update request for Thing with type '%s' and urn '%s' by user '%s' failed: %s\nRequest: %s",
+                             type,
+                             urn,
+                             user,
+                             message,
+                             requestBody);
     }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Improved logging in smartcosmos-edge-things (create, read, update and delete).

### How is this patch documented?

The service now logs all failed queries on log level WARN with user, original request and query result.
Exceptions are logged on log level ERROR, with cause on log level DEBUG.

### How was this patch tested?

JUnit + Postman

#### Depends On

None.