### PR TITLE
Feature/objects 1063

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -5,6 +5,7 @@
 === New Features
 
 * OBJECTS-980 Add Prometheus-compatible `/metrics` endpoint
+* OBJECTS-1063 Implement Retry into Requests
 
 === Bugfixes & Improvements
 

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,10 @@
             <artifactId>spring-cloud-starter-zipkin</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.retry</groupId>
+            <artifactId>spring-retry</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger-ui</artifactId>
             <version>${springfox.version}</version>

--- a/src/main/java/net/smartcosmos/edge/things/ThingEdgeService.java
+++ b/src/main/java/net/smartcosmos/edge/things/ThingEdgeService.java
@@ -4,6 +4,7 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.context.annotation.Import;
+import org.springframework.retry.annotation.EnableRetry;
 
 import net.smartcosmos.annotation.EnableSmartCosmosEvents;
 import net.smartcosmos.annotation.EnableSmartCosmosExtension;
@@ -15,6 +16,7 @@ import net.smartcosmos.edge.things.config.ThingsEdgeConfiguration;
 @EnableSmartCosmosEvents
 @EnableSmartCosmosMonitoring
 @EnableSmartCosmosSecurity
+@EnableRetry
 @EnableSwagger2
 @Import(ThingsEdgeConfiguration.class)
 public class ThingEdgeService {

--- a/src/main/java/net/smartcosmos/edge/things/service/metadata/CreateMetadataRestService.java
+++ b/src/main/java/net/smartcosmos/edge/things/service/metadata/CreateMetadataRestService.java
@@ -3,6 +3,7 @@ package net.smartcosmos.edge.things.service.metadata;
 import java.util.Map;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.retry.annotation.Retryable;
 
 import net.smartcosmos.security.user.SmartCosmosUser;
 
@@ -12,7 +13,8 @@ import net.smartcosmos.security.user.SmartCosmosUser;
 public interface CreateMetadataRestService {
 
     /**
-     * Send request to REST endpoint to create metadata.
+     * <p>Send request to REST endpoint to create metadata.</p>
+     * <p>If the request fails, it is retried 3 times.</p>
      *
      * @param ownerType the type of the owner
      * @param ownerUrn the URN for the owner of the metadata, what the metadata is attached to
@@ -21,5 +23,6 @@ public interface CreateMetadataRestService {
      * @param user the user making the request
      * @return the ResponseEntity
      */
+    @Retryable
     ResponseEntity<?> create(String ownerType, String ownerUrn, Boolean force, Map<String, Object> metadataMap, SmartCosmosUser user);
 }

--- a/src/main/java/net/smartcosmos/edge/things/service/metadata/DeleteMetadataRestService.java
+++ b/src/main/java/net/smartcosmos/edge/things/service/metadata/DeleteMetadataRestService.java
@@ -1,6 +1,7 @@
 package net.smartcosmos.edge.things.service.metadata;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.retry.annotation.Retryable;
 
 import net.smartcosmos.security.user.SmartCosmosUser;
 
@@ -10,12 +11,14 @@ import net.smartcosmos.security.user.SmartCosmosUser;
 public interface DeleteMetadataRestService {
 
     /**
-     * Send request to REST endpoint to delete metadata associated to a thing.
+     * <p>Send request to REST endpoint to delete metadata associated to a thing.</p>
+     * <p>If the request fails, it is retried 3 times.</p>
      *
      * @param ownerType the type of the owner thing
      * @param ownerUrn the URN of the owner thing
      * @param user the user making the request
      * @return the ResponseEntity
      */
+    @Retryable
     ResponseEntity<?> delete(String ownerType, String ownerUrn, SmartCosmosUser user);
 }

--- a/src/main/java/net/smartcosmos/edge/things/service/metadata/GetMetadataRestService.java
+++ b/src/main/java/net/smartcosmos/edge/things/service/metadata/GetMetadataRestService.java
@@ -3,6 +3,7 @@ package net.smartcosmos.edge.things.service.metadata;
 import java.util.Set;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.retry.annotation.Retryable;
 
 import net.smartcosmos.security.user.SmartCosmosUser;
 
@@ -12,7 +13,8 @@ import net.smartcosmos.security.user.SmartCosmosUser;
 public interface GetMetadataRestService {
 
     /**
-     * Look up Metadata associated with a given Thing that match a set of given key names.
+     * <p>Look up Metadata associated with a given Thing that match a set of given key names.</p>
+     * <p>If the request fails, it is retried 3 times.</p>
      *
      * @param ownerType the type of the owner Thing
      * @param ownerUrn the URN of the owner Thing
@@ -20,15 +22,18 @@ public interface GetMetadataRestService {
      * @param user the user making the request
      * @return the response entity
      */
+    @Retryable
     ResponseEntity<?> findByOwner(String ownerType, String ownerUrn, Set<String> keyNames, SmartCosmosUser user);
 
     /**
-     * Look up all Metadata associated with a given Thing.
+     * <p>Look up all Metadata associated with a given Thing.</p>
+     * <p>If the request fails, it is retried 3 times.</p>
      *
      * @param ownerType the type of the owner Thing
      * @param ownerUrn the URN of the owner Thing
      * @param user the user making the request
      * @return the response entity
      */
+    @Retryable
     ResponseEntity<?> findByOwner(String ownerType, String ownerUrn, SmartCosmosUser user);
 }

--- a/src/main/java/net/smartcosmos/edge/things/service/metadata/UpsertMetadataRestService.java
+++ b/src/main/java/net/smartcosmos/edge/things/service/metadata/UpsertMetadataRestService.java
@@ -3,6 +3,7 @@ package net.smartcosmos.edge.things.service.metadata;
 import java.util.Map;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.retry.annotation.Retryable;
 
 import net.smartcosmos.security.user.SmartCosmosUser;
 
@@ -12,7 +13,8 @@ import net.smartcosmos.security.user.SmartCosmosUser;
 public interface UpsertMetadataRestService {
 
     /**
-     * Send request to REST endpoint to upsert Metadata.
+     * <p>Send request to REST endpoint to upsert Metadata.</p>
+     * <p>If the request fails, it is retried 3 times.</p>
      *
      * @param ownerType the type of the owner Thing
      * @param ownerUrn the URN of the owner Thing
@@ -20,5 +22,6 @@ public interface UpsertMetadataRestService {
      * @param user the user making the request
      * @return the ResponseEntity
      */
+    @Retryable
     ResponseEntity<?> upsert(String ownerType, String ownerUrn, Map<String, Object> metadataMap, SmartCosmosUser user);
 }

--- a/src/main/java/net/smartcosmos/edge/things/service/things/CreateThingRestService.java
+++ b/src/main/java/net/smartcosmos/edge/things/service/things/CreateThingRestService.java
@@ -1,6 +1,7 @@
 package net.smartcosmos.edge.things.service.things;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.retry.annotation.Retryable;
 
 import net.smartcosmos.edge.things.domain.things.RestThingCreate;
 import net.smartcosmos.security.user.SmartCosmosUser;
@@ -11,22 +12,26 @@ import net.smartcosmos.security.user.SmartCosmosUser;
 public interface CreateThingRestService {
 
     /**
-     * Send request to REST endpoint to create a thing.
+     * <p>Send request to REST endpoint to create a thing.</p>
+     * <p>If the request fails, it is retried 3 times.</p>
      *
      * @param type the type of the thing
      * @param thingCreate the thing creation request body object
      * @param user the user making the request
      * @return the ResponseEntity
      */
+    @Retryable
     ResponseEntity<?> create(String type, RestThingCreate thingCreate, SmartCosmosUser user);
 
     /**
-     * Send request to REST endpoint to create a thing using the default values.
+     * <p>Send request to REST endpoint to create a thing using the default values.</p>
+     * <p>If the request fails, it is retried 3 times.</p>
      *
      * @param type the type of the thing
      * @param user the user making the request
      * @return the ResponseEntity
      */
+    @Retryable
     ResponseEntity<?> create(String type, SmartCosmosUser user);
 
 }

--- a/src/main/java/net/smartcosmos/edge/things/service/things/DeleteThingRestService.java
+++ b/src/main/java/net/smartcosmos/edge/things/service/things/DeleteThingRestService.java
@@ -1,6 +1,7 @@
 package net.smartcosmos.edge.things.service.things;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.retry.annotation.Retryable;
 
 import net.smartcosmos.security.user.SmartCosmosUser;
 
@@ -10,12 +11,14 @@ import net.smartcosmos.security.user.SmartCosmosUser;
 public interface DeleteThingRestService {
 
     /**
-     * Send request to REST endpoint to delete a thing.
+     * <p>Send request to REST endpoint to delete a thing.</p>
+     * <p>If the request fails, it is retried 3 times.</p>
      *
      * @param type the type of the thing
      * @param urn the URN of the thing
      * @param user the user making the request
      * @return the ResponseEntity
      */
+    @Retryable
     ResponseEntity<?> delete(String type, String urn, SmartCosmosUser user);
 }

--- a/src/main/java/net/smartcosmos/edge/things/service/things/GetThingRestService.java
+++ b/src/main/java/net/smartcosmos/edge/things/service/things/GetThingRestService.java
@@ -1,6 +1,7 @@
 package net.smartcosmos.edge.things.service.things;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.retry.annotation.Retryable;
 
 import net.smartcosmos.security.user.SmartCosmosUser;
 
@@ -10,17 +11,20 @@ import net.smartcosmos.security.user.SmartCosmosUser;
 public interface GetThingRestService {
 
     /**
-     * Look up a Thing by Type and URN.
+     * <p>Look up a Thing by Type and URN.</p>
+     * <p>If the request fails, it is retried 3 times.</p>
      *
      * @param type the type of the Thing
      * @param urn the URN of the Thing
      * @param user the user making the request
      * @return the response entity
      */
+    @Retryable
     ResponseEntity<?> findByTypeAndUrn(String type, String urn, SmartCosmosUser user);
 
     /**
-     * Look up Things by Type.
+     * <p>Look up Things by Type.</p>
+     * <p>If the request fails, it is retried 3 times.</p>
      *
      * @param type the type of the Things
      * @param page the number of the results page
@@ -30,5 +34,6 @@ public interface GetThingRestService {
      * @param user the user making the request
      * @return the response entity with the paged response
      */
+    @Retryable
     ResponseEntity findByType(String type, Integer page, Integer size, String sortOrder, String sortBy, SmartCosmosUser user);
 }

--- a/src/main/java/net/smartcosmos/edge/things/service/things/UpdateThingRestService.java
+++ b/src/main/java/net/smartcosmos/edge/things/service/things/UpdateThingRestService.java
@@ -1,6 +1,7 @@
 package net.smartcosmos.edge.things.service.things;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.retry.annotation.Retryable;
 
 import net.smartcosmos.edge.things.domain.things.RestThingUpdate;
 import net.smartcosmos.security.user.SmartCosmosUser;
@@ -11,7 +12,8 @@ import net.smartcosmos.security.user.SmartCosmosUser;
 public interface UpdateThingRestService {
 
     /**
-     * Send request to REST endpoint to update a thing.
+     * <p>Send request to REST endpoint to update a thing.
+     * <p>If the request fails, it is retried 3 times.</p>
      *
      * @param type the type of the thing to update
      * @param urn the URN of the thing to update
@@ -19,5 +21,6 @@ public interface UpdateThingRestService {
      * @param user the user making the request
      * @return the ResponseEntity
      */
+    @Retryable
     ResponseEntity<?> update(String type, String urn, RestThingUpdate thingUpdate, SmartCosmosUser user);
 }

--- a/src/test/java/net/smartcosmos/edge/things/resource/CreateThingResourceTest.java
+++ b/src/test/java/net/smartcosmos/edge/things/resource/CreateThingResourceTest.java
@@ -26,7 +26,7 @@ import net.smartcosmos.edge.things.domain.things.RestThingCreateResponseDto;
 import net.smartcosmos.edge.things.rest.RestTemplateFactory;
 import net.smartcosmos.edge.things.rest.request.MetadataRequestFactory;
 import net.smartcosmos.edge.things.rest.request.ThingRequestFactory;
-import net.smartcosmos.test.config.ThingsEdgeTestConfig;
+import net.smartcosmos.test.config.ResourceTestConfig;
 import net.smartcosmos.test.security.WithMockSmartCosmosUser;
 
 import static org.hamcrest.Matchers.is;
@@ -51,7 +51,7 @@ import static net.smartcosmos.test.util.TestUtil.json;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @WebAppConfiguration
-@SpringApplicationConfiguration(classes = { ThingEdgeService.class, ThingsEdgeTestConfig.class })
+@SpringApplicationConfiguration(classes = { ThingEdgeService.class, ResourceTestConfig.class })
 @ActiveProfiles("test")
 @WithMockSmartCosmosUser
 public class CreateThingResourceTest {

--- a/src/test/java/net/smartcosmos/edge/things/resource/DeleteThingResourceTest.java
+++ b/src/test/java/net/smartcosmos/edge/things/resource/DeleteThingResourceTest.java
@@ -21,7 +21,7 @@ import net.smartcosmos.edge.things.ThingEdgeService;
 import net.smartcosmos.edge.things.rest.RestTemplateFactory;
 import net.smartcosmos.edge.things.rest.request.MetadataRequestFactory;
 import net.smartcosmos.edge.things.rest.request.ThingRequestFactory;
-import net.smartcosmos.test.config.ThingsEdgeTestConfig;
+import net.smartcosmos.test.config.ResourceTestConfig;
 import net.smartcosmos.test.security.WithMockSmartCosmosUser;
 
 import static org.mockito.BDDMockito.any;
@@ -43,7 +43,7 @@ import static net.smartcosmos.edge.things.resource.ThingEdgeEndpointConstants.EN
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @WebAppConfiguration
-@SpringApplicationConfiguration(classes = { ThingEdgeService.class, ThingsEdgeTestConfig.class })
+@SpringApplicationConfiguration(classes = { ThingEdgeService.class, ResourceTestConfig.class })
 @ActiveProfiles("test")
 @WithMockSmartCosmosUser
 public class DeleteThingResourceTest {

--- a/src/test/java/net/smartcosmos/edge/things/resource/GetThingResourceTest.java
+++ b/src/test/java/net/smartcosmos/edge/things/resource/GetThingResourceTest.java
@@ -30,7 +30,7 @@ import net.smartcosmos.edge.things.domain.things.RestThingResponse;
 import net.smartcosmos.edge.things.rest.RestTemplateFactory;
 import net.smartcosmos.edge.things.rest.request.MetadataRequestFactory;
 import net.smartcosmos.edge.things.rest.request.ThingRequestFactory;
-import net.smartcosmos.test.config.ThingsEdgeTestConfig;
+import net.smartcosmos.test.config.ResourceTestConfig;
 import net.smartcosmos.test.security.WithMockSmartCosmosUser;
 
 import static org.hamcrest.Matchers.hasSize;
@@ -54,7 +54,7 @@ import static net.smartcosmos.edge.things.resource.ThingEdgeEndpointConstants.PA
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @WebAppConfiguration
-@SpringApplicationConfiguration(classes = { ThingEdgeService.class, ThingsEdgeTestConfig.class })
+@SpringApplicationConfiguration(classes = { ThingEdgeService.class, ResourceTestConfig.class })
 @ActiveProfiles("test")
 @WithMockSmartCosmosUser
 public class GetThingResourceTest {

--- a/src/test/java/net/smartcosmos/edge/things/resource/UpdateThingResourceTest.java
+++ b/src/test/java/net/smartcosmos/edge/things/resource/UpdateThingResourceTest.java
@@ -25,7 +25,7 @@ import net.smartcosmos.edge.things.domain.metadata.RestMetadataCreateResponseDto
 import net.smartcosmos.edge.things.rest.RestTemplateFactory;
 import net.smartcosmos.edge.things.rest.request.MetadataRequestFactory;
 import net.smartcosmos.edge.things.rest.request.ThingRequestFactory;
-import net.smartcosmos.test.config.ThingsEdgeTestConfig;
+import net.smartcosmos.test.config.ResourceTestConfig;
 import net.smartcosmos.test.security.WithMockSmartCosmosUser;
 
 import static org.mockito.BDDMockito.any;
@@ -46,7 +46,7 @@ import static net.smartcosmos.test.util.TestUtil.json;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @WebAppConfiguration
-@SpringApplicationConfiguration(classes = { ThingEdgeService.class, ThingsEdgeTestConfig.class })
+@SpringApplicationConfiguration(classes = { ThingEdgeService.class, ResourceTestConfig.class })
 @ActiveProfiles("test")
 @WithMockSmartCosmosUser
 public class UpdateThingResourceTest {

--- a/src/test/java/net/smartcosmos/edge/things/service/metadata/CreateMetadataRestServiceDefaultTest.java
+++ b/src/test/java/net/smartcosmos/edge/things/service/metadata/CreateMetadataRestServiceDefaultTest.java
@@ -1,4 +1,7 @@
-package net.smartcosmos.edge.things.service.things;
+package net.smartcosmos.edge.things.service.metadata;
+
+import java.util.HashMap;
+import java.util.Map;
 
 import org.junit.*;
 import org.junit.runner.RunWith;
@@ -11,12 +14,13 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 
 import net.smartcosmos.edge.things.ThingEdgeService;
-import net.smartcosmos.edge.things.domain.things.RestThingCreate;
 import net.smartcosmos.security.user.SmartCosmosUser;
 import net.smartcosmos.test.config.RetryTestConfig;
 
 import static org.junit.Assert.*;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyMap;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
@@ -33,7 +37,7 @@ import static net.smartcosmos.test.util.TestUtil.unwrapAndVerify;
 @WebAppConfiguration
 @SpringApplicationConfiguration(classes = { ThingEdgeService.class, RetryTestConfig.class })
 @ActiveProfiles("test")
-public class CreateThingRestServiceDefaultTest {
+public class CreateMetadataRestServiceDefaultTest {
 
     /*
      * TODO: 07/11/16 Update test after upgrading to Spring Boot 1.4
@@ -48,7 +52,7 @@ public class CreateThingRestServiceDefaultTest {
 
     // @MockBean // requires at least Spring Boot 1.4.0-RELEASE
     @Autowired
-    private CreateThingRestService service;
+    private CreateMetadataRestService service;
 
     final ResponseEntity expectedResponse = ResponseEntity.status(HttpStatus.I_AM_A_TEAPOT)
         .build();
@@ -58,12 +62,7 @@ public class CreateThingRestServiceDefaultTest {
 
         initMocks(this);
 
-        when(service.create(anyString(), any(SmartCosmosUser.class)))
-            .thenThrow(new RuntimeException("Remote Exception 1"))
-            .thenThrow(new RuntimeException("Remote Exception 2"))
-            .thenReturn(expectedResponse);
-
-        when(service.create(anyString(), any(RestThingCreate.class), any(SmartCosmosUser.class)))
+        when(service.create(anyString(), anyString(), anyBoolean(), anyMap(), any(SmartCosmosUser.class)))
             .thenThrow(new RuntimeException("Remote Exception 1"))
             .thenThrow(new RuntimeException("Remote Exception 2"))
             .thenReturn(expectedResponse);
@@ -83,30 +82,18 @@ public class CreateThingRestServiceDefaultTest {
     }
 
     @Test
-    public void thatCreateThingWithBodyRetries() {
+    public void thatCreateMetadataRetries() {
 
-        final String type = "someType";
-        final RestThingCreate body = mock(RestThingCreate.class);
+        final String ownerType = "someOwnerType";
+        final String ownerUrn = "someOwnerUrn";
+        final Boolean force = true;
+        final Map<String, Object> metadataMap = new HashMap<>();
         final SmartCosmosUser user = mock(SmartCosmosUser.class);
 
-        ResponseEntity response = service.create(type, body, user);
+        ResponseEntity response = service.create(ownerType, ownerUrn, force, metadataMap, user);
 
         assertEquals(expectedResponse, response);
-        unwrapAndVerify(service, times(3)).create(eq(type), eq(body), eq(user));
+        unwrapAndVerify(service, times(3)).create(eq(ownerType), eq(ownerUrn), eq(force), eq(metadataMap), eq(user));
         verifyNoMoreInteractions(service);
     }
-
-    @Test
-    public void thatCreateThingWithoutBodyRetries() {
-
-        final String type = "someType";
-        final SmartCosmosUser user = mock(SmartCosmosUser.class);
-
-        ResponseEntity response = service.create(type, user);
-
-        assertEquals(expectedResponse, response);
-        unwrapAndVerify(service, times(3)).create(eq(type), eq(user));
-        verifyNoMoreInteractions(service);
-    }
-
 }

--- a/src/test/java/net/smartcosmos/edge/things/service/metadata/DeleteMetadataRestServiceDefaultTest.java
+++ b/src/test/java/net/smartcosmos/edge/things/service/metadata/DeleteMetadataRestServiceDefaultTest.java
@@ -1,4 +1,4 @@
-package net.smartcosmos.edge.things.service.things;
+package net.smartcosmos.edge.things.service.metadata;
 
 import org.junit.*;
 import org.junit.runner.RunWith;
@@ -11,7 +11,6 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 
 import net.smartcosmos.edge.things.ThingEdgeService;
-import net.smartcosmos.edge.things.domain.things.RestThingCreate;
 import net.smartcosmos.security.user.SmartCosmosUser;
 import net.smartcosmos.test.config.RetryTestConfig;
 
@@ -33,7 +32,7 @@ import static net.smartcosmos.test.util.TestUtil.unwrapAndVerify;
 @WebAppConfiguration
 @SpringApplicationConfiguration(classes = { ThingEdgeService.class, RetryTestConfig.class })
 @ActiveProfiles("test")
-public class CreateThingRestServiceDefaultTest {
+public class DeleteMetadataRestServiceDefaultTest {
 
     /*
      * TODO: 07/11/16 Update test after upgrading to Spring Boot 1.4
@@ -48,7 +47,7 @@ public class CreateThingRestServiceDefaultTest {
 
     // @MockBean // requires at least Spring Boot 1.4.0-RELEASE
     @Autowired
-    private CreateThingRestService service;
+    private DeleteMetadataRestService service;
 
     final ResponseEntity expectedResponse = ResponseEntity.status(HttpStatus.I_AM_A_TEAPOT)
         .build();
@@ -58,12 +57,7 @@ public class CreateThingRestServiceDefaultTest {
 
         initMocks(this);
 
-        when(service.create(anyString(), any(SmartCosmosUser.class)))
-            .thenThrow(new RuntimeException("Remote Exception 1"))
-            .thenThrow(new RuntimeException("Remote Exception 2"))
-            .thenReturn(expectedResponse);
-
-        when(service.create(anyString(), any(RestThingCreate.class), any(SmartCosmosUser.class)))
+        when(service.delete(anyString(), anyString(), any(SmartCosmosUser.class)))
             .thenThrow(new RuntimeException("Remote Exception 1"))
             .thenThrow(new RuntimeException("Remote Exception 2"))
             .thenReturn(expectedResponse);
@@ -83,30 +77,16 @@ public class CreateThingRestServiceDefaultTest {
     }
 
     @Test
-    public void thatCreateThingWithBodyRetries() {
+    public void thatDeleteMetadataRetries() {
 
-        final String type = "someType";
-        final RestThingCreate body = mock(RestThingCreate.class);
+        final String ownerType = "someOwnerType";
+        final String ownerUrn = "someOwnerUrn";
         final SmartCosmosUser user = mock(SmartCosmosUser.class);
 
-        ResponseEntity response = service.create(type, body, user);
+        ResponseEntity response = service.delete(ownerType, ownerUrn, user);
 
         assertEquals(expectedResponse, response);
-        unwrapAndVerify(service, times(3)).create(eq(type), eq(body), eq(user));
+        unwrapAndVerify(service, times(3)).delete(eq(ownerType), eq(ownerUrn), eq(user));
         verifyNoMoreInteractions(service);
     }
-
-    @Test
-    public void thatCreateThingWithoutBodyRetries() {
-
-        final String type = "someType";
-        final SmartCosmosUser user = mock(SmartCosmosUser.class);
-
-        ResponseEntity response = service.create(type, user);
-
-        assertEquals(expectedResponse, response);
-        unwrapAndVerify(service, times(3)).create(eq(type), eq(user));
-        verifyNoMoreInteractions(service);
-    }
-
 }

--- a/src/test/java/net/smartcosmos/edge/things/service/metadata/GetMetadataRestServiceDefaultTest.java
+++ b/src/test/java/net/smartcosmos/edge/things/service/metadata/GetMetadataRestServiceDefaultTest.java
@@ -1,4 +1,7 @@
-package net.smartcosmos.edge.things.service.things;
+package net.smartcosmos.edge.things.service.metadata;
+
+import java.util.HashSet;
+import java.util.Set;
 
 import org.junit.*;
 import org.junit.runner.RunWith;
@@ -11,12 +14,12 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 
 import net.smartcosmos.edge.things.ThingEdgeService;
-import net.smartcosmos.edge.things.domain.things.RestThingCreate;
 import net.smartcosmos.security.user.SmartCosmosUser;
 import net.smartcosmos.test.config.RetryTestConfig;
 
 import static org.junit.Assert.*;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anySet;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
@@ -33,7 +36,7 @@ import static net.smartcosmos.test.util.TestUtil.unwrapAndVerify;
 @WebAppConfiguration
 @SpringApplicationConfiguration(classes = { ThingEdgeService.class, RetryTestConfig.class })
 @ActiveProfiles("test")
-public class CreateThingRestServiceDefaultTest {
+public class GetMetadataRestServiceDefaultTest {
 
     /*
      * TODO: 07/11/16 Update test after upgrading to Spring Boot 1.4
@@ -48,7 +51,7 @@ public class CreateThingRestServiceDefaultTest {
 
     // @MockBean // requires at least Spring Boot 1.4.0-RELEASE
     @Autowired
-    private CreateThingRestService service;
+    private GetMetadataRestService service;
 
     final ResponseEntity expectedResponse = ResponseEntity.status(HttpStatus.I_AM_A_TEAPOT)
         .build();
@@ -58,12 +61,12 @@ public class CreateThingRestServiceDefaultTest {
 
         initMocks(this);
 
-        when(service.create(anyString(), any(SmartCosmosUser.class)))
+        when(service.findByOwner(anyString(), anyString(), any(SmartCosmosUser.class)))
             .thenThrow(new RuntimeException("Remote Exception 1"))
             .thenThrow(new RuntimeException("Remote Exception 2"))
             .thenReturn(expectedResponse);
 
-        when(service.create(anyString(), any(RestThingCreate.class), any(SmartCosmosUser.class)))
+        when(service.findByOwner(anyString(), anyString(), anySet(), any(SmartCosmosUser.class)))
             .thenThrow(new RuntimeException("Remote Exception 1"))
             .thenThrow(new RuntimeException("Remote Exception 2"))
             .thenReturn(expectedResponse);
@@ -83,30 +86,31 @@ public class CreateThingRestServiceDefaultTest {
     }
 
     @Test
-    public void thatCreateThingWithBodyRetries() {
+    public void thatFindMetadataByOwnerRetries() {
 
-        final String type = "someType";
-        final RestThingCreate body = mock(RestThingCreate.class);
+        final String ownerType = "someOwnerType";
+        final String ownerUrn = "someOwnerUrn";
         final SmartCosmosUser user = mock(SmartCosmosUser.class);
 
-        ResponseEntity response = service.create(type, body, user);
+        ResponseEntity response = service.findByOwner(ownerType, ownerUrn, user);
 
         assertEquals(expectedResponse, response);
-        unwrapAndVerify(service, times(3)).create(eq(type), eq(body), eq(user));
+        unwrapAndVerify(service, times(3)).findByOwner(eq(ownerType), eq(ownerUrn), eq(user));
         verifyNoMoreInteractions(service);
     }
 
     @Test
-    public void thatCreateThingWithoutBodyRetries() {
+    public void thatFindMetadataByOwnerWithKeysRetries() {
 
-        final String type = "someType";
+        final String ownerType = "someOwnerType";
+        final String ownerUrn = "someOwnerUrn";
+        final Set<String> keys = new HashSet<>();
         final SmartCosmosUser user = mock(SmartCosmosUser.class);
 
-        ResponseEntity response = service.create(type, user);
+        ResponseEntity response = service.findByOwner(ownerType, ownerUrn, keys, user);
 
         assertEquals(expectedResponse, response);
-        unwrapAndVerify(service, times(3)).create(eq(type), eq(user));
+        unwrapAndVerify(service, times(3)).findByOwner(eq(ownerType), eq(ownerUrn), eq(keys), eq(user));
         verifyNoMoreInteractions(service);
     }
-
 }

--- a/src/test/java/net/smartcosmos/edge/things/service/metadata/UpsertMetadataRestServiceDefaultTest.java
+++ b/src/test/java/net/smartcosmos/edge/things/service/metadata/UpsertMetadataRestServiceDefaultTest.java
@@ -1,4 +1,7 @@
-package net.smartcosmos.edge.things.service.things;
+package net.smartcosmos.edge.things.service.metadata;
+
+import java.util.HashMap;
+import java.util.Map;
 
 import org.junit.*;
 import org.junit.runner.RunWith;
@@ -11,12 +14,12 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 
 import net.smartcosmos.edge.things.ThingEdgeService;
-import net.smartcosmos.edge.things.domain.things.RestThingCreate;
 import net.smartcosmos.security.user.SmartCosmosUser;
 import net.smartcosmos.test.config.RetryTestConfig;
 
 import static org.junit.Assert.*;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyMap;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
@@ -33,7 +36,7 @@ import static net.smartcosmos.test.util.TestUtil.unwrapAndVerify;
 @WebAppConfiguration
 @SpringApplicationConfiguration(classes = { ThingEdgeService.class, RetryTestConfig.class })
 @ActiveProfiles("test")
-public class CreateThingRestServiceDefaultTest {
+public class UpsertMetadataRestServiceDefaultTest {
 
     /*
      * TODO: 07/11/16 Update test after upgrading to Spring Boot 1.4
@@ -48,7 +51,7 @@ public class CreateThingRestServiceDefaultTest {
 
     // @MockBean // requires at least Spring Boot 1.4.0-RELEASE
     @Autowired
-    private CreateThingRestService service;
+    private UpsertMetadataRestService service;
 
     final ResponseEntity expectedResponse = ResponseEntity.status(HttpStatus.I_AM_A_TEAPOT)
         .build();
@@ -58,12 +61,7 @@ public class CreateThingRestServiceDefaultTest {
 
         initMocks(this);
 
-        when(service.create(anyString(), any(SmartCosmosUser.class)))
-            .thenThrow(new RuntimeException("Remote Exception 1"))
-            .thenThrow(new RuntimeException("Remote Exception 2"))
-            .thenReturn(expectedResponse);
-
-        when(service.create(anyString(), any(RestThingCreate.class), any(SmartCosmosUser.class)))
+        when(service.upsert(anyString(), anyString(), anyMap(), any(SmartCosmosUser.class)))
             .thenThrow(new RuntimeException("Remote Exception 1"))
             .thenThrow(new RuntimeException("Remote Exception 2"))
             .thenReturn(expectedResponse);
@@ -83,30 +81,17 @@ public class CreateThingRestServiceDefaultTest {
     }
 
     @Test
-    public void thatCreateThingWithBodyRetries() {
+    public void thatUpsertMetadataRetries() {
 
-        final String type = "someType";
-        final RestThingCreate body = mock(RestThingCreate.class);
+        final String ownerType = "someOwnerType";
+        final String ownerUrn = "someOwnerUrn";
+        final Map<String, Object> metadataMap = new HashMap<>();
         final SmartCosmosUser user = mock(SmartCosmosUser.class);
 
-        ResponseEntity response = service.create(type, body, user);
+        ResponseEntity response = service.upsert(ownerType, ownerUrn, metadataMap, user);
 
         assertEquals(expectedResponse, response);
-        unwrapAndVerify(service, times(3)).create(eq(type), eq(body), eq(user));
+        unwrapAndVerify(service, times(3)).upsert(eq(ownerType), eq(ownerUrn), eq(metadataMap), eq(user));
         verifyNoMoreInteractions(service);
     }
-
-    @Test
-    public void thatCreateThingWithoutBodyRetries() {
-
-        final String type = "someType";
-        final SmartCosmosUser user = mock(SmartCosmosUser.class);
-
-        ResponseEntity response = service.create(type, user);
-
-        assertEquals(expectedResponse, response);
-        unwrapAndVerify(service, times(3)).create(eq(type), eq(user));
-        verifyNoMoreInteractions(service);
-    }
-
 }

--- a/src/test/java/net/smartcosmos/edge/things/service/things/CreateThingRestServiceDefaultTest.java
+++ b/src/test/java/net/smartcosmos/edge/things/service/things/CreateThingRestServiceDefaultTest.java
@@ -1,0 +1,114 @@
+package net.smartcosmos.edge.things.service.things;
+
+import org.junit.*;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+
+import net.smartcosmos.edge.things.ThingEdgeService;
+import net.smartcosmos.edge.things.domain.things.RestThingCreate;
+import net.smartcosmos.security.user.SmartCosmosUser;
+import net.smartcosmos.test.config.RetryTestConfig;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.validateMockitoUsage;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import static net.smartcosmos.test.util.TestUtil.unwrapAndVerify;
+
+//import static org.mockito.Mockito.unwrapAndVerify;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@WebAppConfiguration
+@SpringApplicationConfiguration(classes = { ThingEdgeService.class, RetryTestConfig.class })
+@ActiveProfiles("test")
+public class CreateThingRestServiceDefaultTest {
+
+    /*
+     * TODO: 07/11/16 Update test after upgrading to Spring Boot 1.4
+     *
+     * The currently used version of Spring Boot requires unwrapping the bean to verify @Retryable methods when mock() is used to create the mocked
+     * bean. Otherwise a UnfinishedVerificationException would be thrown.
+     *
+     * Once Spring Boot is upgraded and @MockBean replaced mock(), unwrapAndVerify() can be replaced by Mockito.verify() again.
+     *
+     * (see https://github.com/spring-projects/spring-boot/issues/6828)
+     */
+
+    // @MockBean // requires at least Spring Boot 1.4.0-RELEASE
+    @Autowired
+    private CreateThingRestService service;
+
+    final ResponseEntity expectedResponse = ResponseEntity.status(HttpStatus.I_AM_A_TEAPOT)
+        .build();
+
+    @Before
+    public void setUp() {
+
+        initMocks(this);
+
+        when(service.create(anyString(), any(SmartCosmosUser.class)))
+            .thenThrow(new RuntimeException("Remote Exception 1"))
+            .thenThrow(new RuntimeException("Remote Exception 2"))
+            .thenReturn(expectedResponse);
+
+        when(service.create(anyString(), any(RestThingCreate.class), any(SmartCosmosUser.class)))
+            .thenThrow(new RuntimeException("Remote Exception 1"))
+            .thenThrow(new RuntimeException("Remote Exception 2"))
+            .thenReturn(expectedResponse);
+    }
+
+    @After
+    public void tearDown() {
+
+        validateMockitoUsage();
+        reset(service);
+    }
+
+    @Test
+    public void thatApplicationContextLoads() {
+
+        assertNotNull(service);
+    }
+
+    @Test
+    public void thatCreateThingWithBodyRetries() {
+
+        final String type = "someType";
+        final RestThingCreate body = mock(RestThingCreate.class);
+        final SmartCosmosUser user = mock(SmartCosmosUser.class);
+
+        ResponseEntity response = service.create(type, body, user);
+
+        assertEquals(expectedResponse, response);
+        unwrapAndVerify(service, times(3)).create(eq(type), eq(body), eq(user));
+        verifyNoMoreInteractions(service);
+    }
+
+    @Test
+    public void thatCreateThingWithoutBodyRetries() {
+
+        final String type = "someType";
+        final SmartCosmosUser user = mock(SmartCosmosUser.class);
+
+        ResponseEntity response = service.create(type, user);
+
+        assertEquals(expectedResponse, response);
+        unwrapAndVerify(service, times(3)).create(eq(type), eq(user));
+        verifyNoMoreInteractions(service);
+    }
+
+}

--- a/src/test/java/net/smartcosmos/edge/things/service/things/DeleteThingRestServiceDefaultTest.java
+++ b/src/test/java/net/smartcosmos/edge/things/service/things/DeleteThingRestServiceDefaultTest.java
@@ -1,0 +1,92 @@
+package net.smartcosmos.edge.things.service.things;
+
+import org.junit.*;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+
+import net.smartcosmos.edge.things.ThingEdgeService;
+import net.smartcosmos.security.user.SmartCosmosUser;
+import net.smartcosmos.test.config.RetryTestConfig;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.validateMockitoUsage;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import static net.smartcosmos.test.util.TestUtil.unwrapAndVerify;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@WebAppConfiguration
+@SpringApplicationConfiguration(classes = { ThingEdgeService.class, RetryTestConfig.class })
+@ActiveProfiles("test")
+public class DeleteThingRestServiceDefaultTest {
+
+    /*
+     * TODO: 07/11/16 Update test after upgrading to Spring Boot 1.4
+     *
+     * The currently used version of Spring Boot requires unwrapping the bean to verify @Retryable methods when mock() is used to create the mocked
+     * bean. Otherwise a UnfinishedVerificationException would be thrown.
+     *
+     * Once Spring Boot is upgraded and @MockBean replaced mock(), unwrapAndVerify() can be replaced by Mockito.verify() again.
+     *
+     * (see https://github.com/spring-projects/spring-boot/issues/6828)
+     */
+
+    // @MockBean // requires at least Spring Boot 1.4.0-RELEASE
+    @Autowired
+    private DeleteThingRestService service;
+
+    final ResponseEntity expectedResponse = ResponseEntity.status(HttpStatus.I_AM_A_TEAPOT)
+        .build();
+
+    @Before
+    public void setUp() {
+
+        initMocks(this);
+
+        when(service.delete(anyString(), anyString(), any(SmartCosmosUser.class)))
+            .thenThrow(new RuntimeException("Remote Exception 1"))
+            .thenThrow(new RuntimeException("Remote Exception 2"))
+            .thenReturn(expectedResponse);
+    }
+
+    @After
+    public void tearDown() {
+
+        validateMockitoUsage();
+        reset(service);
+    }
+
+    @Test
+    public void thatApplicationContextLoads() {
+
+        assertNotNull(service);
+    }
+
+    @Test
+    public void thatDeleteThingRetries() {
+
+        final String type = "someType";
+        final String urn = "someUrn";
+        final SmartCosmosUser user = mock(SmartCosmosUser.class);
+
+        ResponseEntity response = service.delete(type, urn, user);
+
+        assertEquals(expectedResponse, response);
+        unwrapAndVerify(service, times(3)).delete(eq(type), eq(urn), eq(user));
+        verifyNoMoreInteractions(service);
+    }
+}

--- a/src/test/java/net/smartcosmos/edge/things/service/things/GetThingRestServiceDefaultTest.java
+++ b/src/test/java/net/smartcosmos/edge/things/service/things/GetThingRestServiceDefaultTest.java
@@ -1,0 +1,111 @@
+package net.smartcosmos.edge.things.service.things;
+
+import org.junit.*;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+
+import net.smartcosmos.edge.things.ThingEdgeService;
+import net.smartcosmos.security.user.SmartCosmosUser;
+import net.smartcosmos.test.config.RetryTestConfig;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.validateMockitoUsage;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import static net.smartcosmos.test.util.TestUtil.unwrapAndVerify;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@WebAppConfiguration
+@SpringApplicationConfiguration(classes = { ThingEdgeService.class, RetryTestConfig.class })
+@ActiveProfiles("test")
+public class GetThingRestServiceDefaultTest {
+
+    /*
+     * TODO: 07/11/16 Update test after upgrading to Spring Boot 1.4
+     *
+     * The currently used version of Spring Boot requires unwrapping the bean to verify @Retryable methods when mock() is used to create the mocked
+     * bean. Otherwise a UnfinishedVerificationException would be thrown.
+     *
+     * Once Spring Boot is upgraded and @MockBean replaced mock(), unwrapAndVerify() can be replaced by Mockito.verify() again.
+     *
+     * (see https://github.com/spring-projects/spring-boot/issues/6828)
+     */
+
+    // @MockBean // requires at least Spring Boot 1.4.0-RELEASE
+    @Autowired
+    private GetThingRestService service;
+
+    final ResponseEntity expectedResponse = ResponseEntity.status(HttpStatus.I_AM_A_TEAPOT)
+        .build();
+
+    @Before
+    public void setUp() {
+
+        initMocks(this);
+
+        when(service.findByTypeAndUrn(anyString(), anyString(), any(SmartCosmosUser.class)))
+            .thenThrow(new RuntimeException("Remote Exception 1"))
+            .thenThrow(new RuntimeException("Remote Exception 2"))
+            .thenReturn(expectedResponse);
+
+        when(service.findByType(anyString(), anyInt(), anyInt(), anyString(), anyString(), any(SmartCosmosUser.class)))
+            .thenThrow(new RuntimeException("Remote Exception 1"))
+            .thenThrow(new RuntimeException("Remote Exception 2"))
+            .thenReturn(expectedResponse);
+    }
+
+    @After
+    public void tearDown() {
+
+        validateMockitoUsage();
+        reset(service);
+    }
+
+    @Test
+    public void thatApplicationContextLoads() {
+
+        assertNotNull(service);
+    }
+
+    @Test
+    public void thatGetThingByTypeAndUrnRetries() {
+
+        final String type = "someType";
+        final String urn = "someUrn";
+        final SmartCosmosUser user = mock(SmartCosmosUser.class);
+
+        ResponseEntity response = service.findByTypeAndUrn(type, urn, user);
+
+        assertEquals(expectedResponse, response);
+        unwrapAndVerify(service, times(3)).findByTypeAndUrn(eq(type), eq(urn), eq(user));
+        verifyNoMoreInteractions(service);
+    }
+
+    @Test
+    public void thatGetThingByTypeRetries() {
+
+        final String type = "someType";
+        final SmartCosmosUser user = mock(SmartCosmosUser.class);
+
+        ResponseEntity response = service.findByType(type, 1, 10, null, null, user);
+
+        assertEquals(expectedResponse, response);
+        unwrapAndVerify(service, times(3)).findByType(eq(type), anyInt(), anyInt(), anyString(), anyString(), eq(user));
+        verifyNoMoreInteractions(service);
+    }
+}

--- a/src/test/java/net/smartcosmos/edge/things/service/things/UpdateThingRestServiceDefaultTest.java
+++ b/src/test/java/net/smartcosmos/edge/things/service/things/UpdateThingRestServiceDefaultTest.java
@@ -1,0 +1,94 @@
+package net.smartcosmos.edge.things.service.things;
+
+import org.junit.*;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+
+import net.smartcosmos.edge.things.ThingEdgeService;
+import net.smartcosmos.edge.things.domain.things.RestThingUpdate;
+import net.smartcosmos.security.user.SmartCosmosUser;
+import net.smartcosmos.test.config.RetryTestConfig;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.validateMockitoUsage;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import static net.smartcosmos.test.util.TestUtil.unwrapAndVerify;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@WebAppConfiguration
+@SpringApplicationConfiguration(classes = { ThingEdgeService.class, RetryTestConfig.class })
+@ActiveProfiles("test")
+public class UpdateThingRestServiceDefaultTest {
+
+    /*
+     * TODO: 07/11/16 Update test after upgrading to Spring Boot 1.4
+     *
+     * The currently used version of Spring Boot requires unwrapping the bean to verify @Retryable methods when mock() is used to create the mocked
+     * bean. Otherwise a UnfinishedVerificationException would be thrown.
+     *
+     * Once Spring Boot is upgraded and @MockBean replaced mock(), unwrapAndVerify() can be replaced by Mockito.verify() again.
+     *
+     * (see https://github.com/spring-projects/spring-boot/issues/6828)
+     */
+
+    // @MockBean // requires at least Spring Boot 1.4.0-RELEASE
+    @Autowired
+    private UpdateThingRestService service;
+
+    final ResponseEntity expectedResponse = ResponseEntity.status(HttpStatus.I_AM_A_TEAPOT)
+        .build();
+
+    @Before
+    public void setUp() {
+
+        initMocks(this);
+
+        when(service.update(anyString(), anyString(), any(RestThingUpdate.class), any(SmartCosmosUser.class)))
+            .thenThrow(new RuntimeException("Remote Exception 1"))
+            .thenThrow(new RuntimeException("Remote Exception 2"))
+            .thenReturn(expectedResponse);
+    }
+
+    @After
+    public void tearDown() {
+
+        validateMockitoUsage();
+        reset(service);
+    }
+
+    @Test
+    public void thatApplicationContextLoads() {
+
+        assertNotNull(service);
+    }
+
+    @Test
+    public void thatGetThingByTypeAndUrnRetries() {
+
+        final String type = "someType";
+        final String urn = "someUrn";
+        final RestThingUpdate body = mock(RestThingUpdate.class);
+        final SmartCosmosUser user = mock(SmartCosmosUser.class);
+
+        ResponseEntity response = service.update(type, urn, body, user);
+
+        assertEquals(expectedResponse, response);
+        unwrapAndVerify(service, times(3)).update(eq(type), eq(urn), eq(body), eq(user));
+        verifyNoMoreInteractions(service);
+    }
+}

--- a/src/test/java/net/smartcosmos/test/config/ResourceTestConfig.java
+++ b/src/test/java/net/smartcosmos/test/config/ResourceTestConfig.java
@@ -11,7 +11,7 @@ import net.smartcosmos.edge.things.rest.request.ThingRequestFactory;
 import static org.mockito.Mockito.mock;
 
 @Configuration
-public class ThingsEdgeTestConfig {
+public class ResourceTestConfig {
 
     @Bean
     public OAuth2ProtectedResourceDetails oAuth2ProtectedResourceDetails() {

--- a/src/test/java/net/smartcosmos/test/config/RetryTestConfig.java
+++ b/src/test/java/net/smartcosmos/test/config/RetryTestConfig.java
@@ -1,0 +1,82 @@
+package net.smartcosmos.test.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+
+import net.smartcosmos.edge.things.service.metadata.CreateMetadataRestService;
+import net.smartcosmos.edge.things.service.metadata.DeleteMetadataRestService;
+import net.smartcosmos.edge.things.service.metadata.GetMetadataRestService;
+import net.smartcosmos.edge.things.service.metadata.UpsertMetadataRestService;
+import net.smartcosmos.edge.things.service.things.CreateThingRestService;
+import net.smartcosmos.edge.things.service.things.DeleteThingRestService;
+import net.smartcosmos.edge.things.service.things.GetThingRestService;
+import net.smartcosmos.edge.things.service.things.UpdateThingRestService;
+
+import static org.mockito.Mockito.mock;
+
+public class RetryTestConfig {
+
+    // region Thing services
+
+    @Primary
+    @Bean
+    public CreateThingRestService createThingRestService() {
+
+        return mock(CreateThingRestService.class);
+    }
+
+    @Primary
+    @Bean
+    public DeleteThingRestService deleteThingRestService() {
+
+        return mock(DeleteThingRestService.class);
+    }
+
+    @Primary
+    @Bean
+    public GetThingRestService getThingRestService() {
+
+        return mock(GetThingRestService.class);
+    }
+
+    @Primary
+    @Bean
+    public UpdateThingRestService updateThingRestService() {
+
+        return mock(UpdateThingRestService.class);
+    }
+
+    // endregion
+
+    // region Metadata services
+
+    @Primary
+    @Bean
+    public CreateMetadataRestService createMetadataRestService() {
+
+        return mock(CreateMetadataRestService.class);
+    }
+
+    @Primary
+    @Bean
+    public DeleteMetadataRestService deleteMetadataRestService() {
+
+        return mock(DeleteMetadataRestService.class);
+    }
+
+    @Primary
+    @Bean
+    public GetMetadataRestService getMetadataRestService() {
+
+        return mock(GetMetadataRestService.class);
+    }
+
+    @Primary
+    @Bean
+    public UpsertMetadataRestService upsertMetadataRestService() {
+
+        return mock(UpsertMetadataRestService.class);
+    }
+
+    // endregion
+}

--- a/src/test/java/net/smartcosmos/test/util/TestUtil.java
+++ b/src/test/java/net/smartcosmos/test/util/TestUtil.java
@@ -5,6 +5,10 @@ import java.io.IOException;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import org.mockito.*;
+import org.mockito.verification.VerificationMode;
+import org.springframework.test.util.AopTestUtils;
+
 /**
  * Utility methods for unit tests.
  */
@@ -17,4 +21,19 @@ public class TestUtil {
         return mapper.writeValueAsBytes(object);
     }
 
+    /**
+     * <p>Verifies certain behavior happened at least once / exact number of times / never.</p>
+     * <p>This is a helper method that uses {@link AopTestUtils} to work around an issue with Mockito and AOP like {@code @Retryable} that requires
+     * unwrapping if the mock is created using {@code mock()}.</p>
+     *
+     * @param mock the mock
+     * @param mode the mode
+     * @param <T> the type of the wrapped object
+     * @return mock object itself
+     * @see Mockito#verify
+     */
+    public static <T> T unwrapAndVerify(T mock, VerificationMode mode) {
+
+        return ((T) Mockito.verify(AopTestUtils.getTargetObject(mock), mode));
+    }
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,12 +1,8 @@
-eureka:
-  client:
-    enabled: false
 logging:
   pattern:
     console: "%d %-5level %logger : %msg%n"
   level:
-    ROOT: WARN
-    #net.smartcosmos: TRACE
-    org.springframework: WARN
-    #org.springframework.beans: TRACE
-    com.netflix.eureka.registry: WARN
+    ROOT: INFO
+    org.springframework.security: WARN
+    org.springframework.web: WARN
+    springfox: WARN

--- a/src/test/resources/application-trace.yml
+++ b/src/test/resources/application-trace.yml
@@ -1,0 +1,4 @@
+logging:
+  level:
+    ROOT: DEBUG
+    net.smartcosmos: TRACE

--- a/src/test/resources/bootstrap-test.yml
+++ b/src/test/resources/bootstrap-test.yml
@@ -1,5 +1,5 @@
 server:
-  port: 45336
+  port: 0
 
 security:
   user:
@@ -10,16 +10,6 @@ spring:
 smartcosmos:
   security:
     enabled: false
-
-logging:
-  level:
-    ROOT: INFO
-    net.smartcosmos: TRACE
-    org.springframework.security: TRACE
-    org.springframework.web: TRACE
-    #org.springframework.beans: TRACE
-    com.netflix.eureka.registry: WARN
-    springfox: TRACE
 
 # springfox:
 #    documentation:

--- a/src/test/resources/bootstrap-trace.yml
+++ b/src/test/resources/bootstrap-trace.yml
@@ -1,0 +1,4 @@
+logging:
+  level:
+    ROOT: DEBUG
+    net.smartcosmos: TRACE


### PR DESCRIPTION
### What changes were proposed in this pull request?

- adds Retry to the services classes that do inter-service calls (using spring-retry defaults)
- cleans up and updates the YML properties for tests, and also adds a `trace` profile as a reference.

### How is this patch documented?

- Code
- Javadoc

### How was this patch tested?

Existing and additional unit tests.

#### Depends On

Nothing.