### PR TITLE
Bugfix/objects 1128 metadata error message

### DIFF
--- a/src/main/java/net/smartcosmos/edge/things/domain/metadata/RestMetadataCreateResponseDto.java
+++ b/src/main/java/net/smartcosmos/edge/things/domain/metadata/RestMetadataCreateResponseDto.java
@@ -1,6 +1,7 @@
 package net.smartcosmos.edge.things.domain.metadata;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -12,6 +13,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @Data
 @JsonIgnoreProperties({ "version" })
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class RestMetadataCreateResponseDto {
 
     private static final int VERSION_1 = 1;
@@ -19,4 +21,8 @@ public class RestMetadataCreateResponseDto {
     private final int version = VERSION_1;
 
     private String uri;
+
+    private int code;
+
+    private String message;
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

* forwards the error message from metadata core in case of failed metadata creation

### How is this patch documented?

* includes `code` and `message` from the metadata response into the error response

### How was this patch tested?

* Postman
* JUnit (additional unit test created in this fix)

#### Depends On

None.
