### PR TITLE
return generic response entity on create metadata

### DIFF
--- a/src/main/java/net/smartcosmos/edge/things/domain/metadata/RestMetadataCreateResponseDto.java
+++ b/src/main/java/net/smartcosmos/edge/things/domain/metadata/RestMetadataCreateResponseDto.java
@@ -1,7 +1,6 @@
 package net.smartcosmos.edge.things.domain.metadata;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -13,7 +12,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @Data
 @JsonIgnoreProperties({ "version" })
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public class RestMetadataCreateResponseDto {
 
     private static final int VERSION_1 = 1;
@@ -21,8 +19,4 @@ public class RestMetadataCreateResponseDto {
     private final int version = VERSION_1;
 
     private String uri;
-
-    private int code;
-
-    private String message;
 }

--- a/src/main/java/net/smartcosmos/edge/things/service/metadata/CreateMetadataRestServiceDefault.java
+++ b/src/main/java/net/smartcosmos/edge/things/service/metadata/CreateMetadataRestServiceDefault.java
@@ -9,7 +9,6 @@ import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
-import net.smartcosmos.edge.things.domain.metadata.RestMetadataCreateResponseDto;
 import net.smartcosmos.edge.things.rest.RestTemplateFactory;
 import net.smartcosmos.edge.things.rest.request.MetadataRequestFactory;
 import net.smartcosmos.security.user.SmartCosmosUser;
@@ -37,6 +36,6 @@ public class CreateMetadataRestServiceDefault implements CreateMetadataRestServi
         RequestEntity<Map<String, Object>> requestEntity = requestFactory.createOrUpsertRequest(ownerType, ownerUrn, force, metadataMap);
 
         return restTemplateFactory.getRestTemplate()
-            .exchange(requestEntity, RestMetadataCreateResponseDto.class);
+            .exchange(requestEntity, Object.class);
     }
 }

--- a/src/main/java/net/smartcosmos/edge/things/service/metadata/UpsertMetadataRestServiceDefault.java
+++ b/src/main/java/net/smartcosmos/edge/things/service/metadata/UpsertMetadataRestServiceDefault.java
@@ -9,7 +9,6 @@ import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
-import net.smartcosmos.edge.things.domain.metadata.RestMetadataCreateResponseDto;
 import net.smartcosmos.edge.things.rest.RestTemplateFactory;
 import net.smartcosmos.edge.things.rest.request.MetadataRequestFactory;
 import net.smartcosmos.security.user.SmartCosmosUser;
@@ -37,6 +36,6 @@ public class UpsertMetadataRestServiceDefault implements UpsertMetadataRestServi
         RequestEntity<Map<String, Object>> requestEntity = requestFactory.createOrUpsertRequest(ownerType, ownerUrn, true, metadataMap);
 
         return restTemplateFactory.getRestTemplate()
-            .exchange(requestEntity, RestMetadataCreateResponseDto.class);
+            .exchange(requestEntity, Object.class);
     }
 }

--- a/src/test/java/net/smartcosmos/edge/things/domain/CodeMessageErrorResponse.java
+++ b/src/test/java/net/smartcosmos/edge/things/domain/CodeMessageErrorResponse.java
@@ -12,7 +12,7 @@ package net.smartcosmos.edge.things.domain;
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @Data
 @JsonIgnoreProperties({ "version" })
-public class RestMetadataCreateErrorResponseTest {
+public class CodeMessageErrorResponse {
 
     private static final int VERSION_1 = 1;
 

--- a/src/test/java/net/smartcosmos/edge/things/domain/RestMetadataCreateErrorResponseTest.java
+++ b/src/test/java/net/smartcosmos/edge/things/domain/RestMetadataCreateErrorResponseTest.java
@@ -1,0 +1,24 @@
+package net.smartcosmos.edge.things.domain;
+
+    import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+    import lombok.AccessLevel;
+    import lombok.AllArgsConstructor;
+    import lombok.Builder;
+    import lombok.Data;
+    import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Data
+@JsonIgnoreProperties({ "version" })
+public class RestMetadataCreateErrorResponseTest {
+
+    private static final int VERSION_1 = 1;
+
+    private final int version = VERSION_1;
+
+    private int code;
+
+    private String message;
+}

--- a/src/test/java/net/smartcosmos/edge/things/resource/CreateThingResourceTest.java
+++ b/src/test/java/net/smartcosmos/edge/things/resource/CreateThingResourceTest.java
@@ -21,6 +21,7 @@ import org.springframework.web.client.RestTemplate;
 import org.springframework.web.context.WebApplicationContext;
 
 import net.smartcosmos.edge.things.ThingEdgeService;
+import net.smartcosmos.edge.things.domain.RestMetadataCreateErrorResponseTest;
 import net.smartcosmos.edge.things.domain.metadata.RestMetadataCreateResponseDto;
 import net.smartcosmos.edge.things.domain.things.RestThingCreateResponseDto;
 import net.smartcosmos.edge.things.rest.RestTemplateFactory;
@@ -128,7 +129,7 @@ public class CreateThingResourceTest {
         willReturn(thingResponseEntity).given(restTemplate)
             .exchange(any(RequestEntity.class), eq(RestThingCreateResponseDto.class));
         willReturn(metadataResponseEntity).given(restTemplate)
-            .exchange(any(RequestEntity.class), eq(RestMetadataCreateResponseDto.class));
+            .exchange(any(RequestEntity.class), eq(Object.class));
 
         byte[] jsonDto = json(requestBody);
         MvcResult mvcResult = this.mockMvc.perform(
@@ -148,7 +149,7 @@ public class CreateThingResourceTest {
             .andExpect(jsonPath("$.active", is(expectedActive)));
 
         verify(restTemplate, times(1)).exchange(any(RequestEntity.class), eq(RestThingCreateResponseDto.class));
-        verify(restTemplate, times(1)).exchange(any(RequestEntity.class), eq(RestMetadataCreateResponseDto.class));
+        verify(restTemplate, times(1)).exchange(any(RequestEntity.class), eq(Object.class));
         verifyNoMoreInteractions(restTemplate);
     }
 
@@ -267,7 +268,7 @@ public class CreateThingResourceTest {
         final ResponseEntity<?> metadataResponseEntity = new ResponseEntity<>(metadataResponseBody, HttpStatus.OK);
 
         willReturn(metadataResponseEntity).given(restTemplate)
-            .exchange(any(RequestEntity.class), eq(RestMetadataCreateResponseDto.class));
+            .exchange(any(RequestEntity.class), eq(Object.class));
 
         HashMap<String, Object> requestBody = new HashMap<>();
         requestBody.put("urn", expectedUrn);
@@ -287,7 +288,7 @@ public class CreateThingResourceTest {
             .andExpect(status().isConflict());
 
         verify(restTemplate, times(1)).exchange(any(RequestEntity.class), eq(RestThingCreateResponseDto.class));
-        verify(restTemplate, times(1)).exchange(any(RequestEntity.class), eq(RestMetadataCreateResponseDto.class));
+        verify(restTemplate, times(1)).exchange(any(RequestEntity.class), eq(Object.class));
         verifyNoMoreInteractions(restTemplate);
     }
 
@@ -348,7 +349,7 @@ public class CreateThingResourceTest {
             .build();
         final ResponseEntity<?> thingResponseEntity = new ResponseEntity<>(thingResponseBody, HttpStatus.CREATED);
 
-        final RestMetadataCreateResponseDto metadataResponseBody = RestMetadataCreateResponseDto.builder()
+        final RestMetadataCreateErrorResponseTest metadataResponseBody = RestMetadataCreateErrorResponseTest.builder()
             .code(errorCode)
             .message(errorMessage)
             .build();
@@ -362,7 +363,7 @@ public class CreateThingResourceTest {
         willReturn(thingResponseEntity).given(restTemplate)
             .exchange(any(RequestEntity.class), eq(RestThingCreateResponseDto.class));
         willReturn(metadataResponseEntity).given(restTemplate)
-            .exchange(any(RequestEntity.class), eq(RestMetadataCreateResponseDto.class));
+            .exchange(any(RequestEntity.class), eq(Object.class));
 
         byte[] jsonDto = json(requestBody);
         MvcResult mvcResult = this.mockMvc.perform(
@@ -380,7 +381,7 @@ public class CreateThingResourceTest {
             .andExpect(jsonPath("$.message", is(errorMessage)));
 
         verify(restTemplate, times(1)).exchange(any(RequestEntity.class), eq(RestThingCreateResponseDto.class));
-        verify(restTemplate, times(1)).exchange(any(RequestEntity.class), eq(RestMetadataCreateResponseDto.class));
+        verify(restTemplate, times(1)).exchange(any(RequestEntity.class), eq(Object.class));
         verifyNoMoreInteractions(restTemplate);
     }
 }

--- a/src/test/java/net/smartcosmos/edge/things/resource/CreateThingResourceTest.java
+++ b/src/test/java/net/smartcosmos/edge/things/resource/CreateThingResourceTest.java
@@ -21,7 +21,7 @@ import org.springframework.web.client.RestTemplate;
 import org.springframework.web.context.WebApplicationContext;
 
 import net.smartcosmos.edge.things.ThingEdgeService;
-import net.smartcosmos.edge.things.domain.RestMetadataCreateErrorResponseTest;
+import net.smartcosmos.edge.things.domain.CodeMessageErrorResponse;
 import net.smartcosmos.edge.things.domain.metadata.RestMetadataCreateResponseDto;
 import net.smartcosmos.edge.things.domain.things.RestThingCreateResponseDto;
 import net.smartcosmos.edge.things.rest.RestTemplateFactory;
@@ -349,7 +349,7 @@ public class CreateThingResourceTest {
             .build();
         final ResponseEntity<?> thingResponseEntity = new ResponseEntity<>(thingResponseBody, HttpStatus.CREATED);
 
-        final RestMetadataCreateErrorResponseTest metadataResponseBody = RestMetadataCreateErrorResponseTest.builder()
+        final CodeMessageErrorResponse metadataResponseBody = CodeMessageErrorResponse.builder()
             .code(errorCode)
             .message(errorMessage)
             .build();


### PR DESCRIPTION
### What changes were proposed in this pull request?

* return a generic response from create metadata inside create things
* so the inner response could have any JSON scheme

#### Note
* create and update have been updated
* read already has an exception handler
* delete does not expect a response body, so this would require bigger modifications to fix

### How is this patch documented?

* code

### How was this patch tested?

* JUnit tests updated
* Tested also with Postman in DevKit

#### Depends On

None.